### PR TITLE
Native callbacks use std::function

### DIFF
--- a/src/cidart/Script.cpp
+++ b/src/cidart/Script.cpp
@@ -96,7 +96,7 @@ string  Script::loadSourceImpl( const DataSourceRef &dataSource )
 }
 
 // ----------------------------------------------------------------------------------------------------
-// MARK: - Dart Callbacks
+// MARK: - Dart API Callbacks
 // ----------------------------------------------------------------------------------------------------
 
 // static
@@ -217,7 +217,7 @@ Dart_Handle Script::libraryTagHandler( Dart_LibraryTag tag, Dart_Handle library,
 }
 
 // static
-Dart_NativeFunction Script::resolveNameHandler( Dart_Handle nameHandle, int numArgs, bool* auto_setup_scope )
+Dart_NativeFunction Script::resolveNameHandler( Dart_Handle nameHandle, int numArgs, bool *autoSetupScope )
 {
 	CI_ASSERT( Dart_IsString( nameHandle ) );
 
@@ -229,6 +229,10 @@ Dart_NativeFunction Script::resolveNameHandler( Dart_Handle nameHandle, int numA
 	script->mLatestNativeCallbackName = getValue<string>( nameHandle );
 	return nativeCallbackHandler;
 }
+
+// ----------------------------------------------------------------------------------------------------
+// MARK: - Native Callbacks
+// ----------------------------------------------------------------------------------------------------
 
 // Static
 void Script::nativeCallbackHandler( Dart_NativeArguments args )

--- a/src/cidart/Script.cpp
+++ b/src/cidart/Script.cpp
@@ -253,12 +253,10 @@ void Script::nativeCallbackHandler( Dart_NativeArguments args )
 }
 
 // static
-void Script::printNative( Dart_NativeArguments arguments )
+void Script::printNative( Dart_NativeArguments args )
 {
-	Dart_Handle handle = Dart_GetNativeArgument( arguments, 0 );
-	CIDART_CHECK( handle );
-
-	ci::app::console() << "|dart| " << getValue<string>( handle ) << std::endl;
+	string message = getArg<string>( args, 0 );
+	ci::app::console() << "|dart| " << message << std::endl;
 }
 
 void Script::toCinder( Dart_NativeArguments args )

--- a/src/cidart/Script.h
+++ b/src/cidart/Script.h
@@ -20,9 +20,7 @@ typedef std::map<std::string, NativeCallback>			NativeCallbackMap;
 typedef std::map<std::string, Dart_Handle>	DataMap;
 typedef std::function<void( const DataMap& )>			ReceiveMapCallback;
 
-// TODO: consider whether to name this Isolate or Script
-// - is it at all useful to create an Isolate that doesn't spawn a new script?
-// - need to read up more on how Isolates are created in plain dart, and their uses
+//! Class representing a dart script.
 class Script {
   public:
 	struct Options {

--- a/src/cidart/Script.h
+++ b/src/cidart/Script.h
@@ -38,11 +38,15 @@ class Script {
 		ReceiveMapCallback			mReceiveMapCallback;
 	};
 
+	//! Creates a new Script object from the dart file located at \a sourcePath.
+	static ScriptRef	create( const ci::fs::path &sourcePath, const Options &options = Options() )	{ return ScriptRef( new Script( sourcePath, options ) ); }
+	//! Creates a new Script object from the dart file located at \a source. \note Only file-based `DataSource`s are supported.
 	static ScriptRef	create( const ci::DataSourceRef &source, const Options &options = Options() )	{ return ScriptRef( new Script( source, options ) ); }
 
 	void invoke( const std::string &functionName, int argc = 0, Dart_Handle *args = nullptr );
 
   private:
+	Script( const ci::fs::path &sourcePath, const Options &options );
 	Script( const ci::DataSourceRef &source, const Options &options );
 
 	// Dart_IsolateCreateCallback
@@ -58,8 +62,8 @@ class Script {
 	static void printNative( Dart_NativeArguments arguments );
 	void toCinder( Dart_NativeArguments arguments );
 
-	std::string  loadSourceImpl( const ci::fs::path &sourcePath );
-	std::string  loadSourceImpl( const ci::DataSourceRef &dataSource );
+	void			init();
+	std::string		loadSourceImpl( const ci::fs::path &sourcePath );
 
 	Dart_Isolate				mIsolate;
 	ci::fs::path				mMainScriptPath;

--- a/src/cidart/Script.h
+++ b/src/cidart/Script.h
@@ -46,11 +46,11 @@ class Script {
 	Script( const ci::DataSourceRef &source, const Options &options );
 
 	// Dart_IsolateCreateCallback
-	static Dart_Isolate createIsolateCallback( const char* script_uri, const char* main, const char *packageRoot, void* callbackData, char** error );
+	static Dart_Isolate createIsolateCallback( const char *scriptUri, const char *main, const char *packageRoot, void *callbackData, char **error );
 	// Dart_LibraryTagHandler
 	static Dart_Handle libraryTagHandler( Dart_LibraryTag tag, Dart_Handle library, Dart_Handle urlHandle );
 	// Dart_NativeEntryResolver
-	static Dart_NativeFunction resolveNameHandler( Dart_Handle nameHandle, int numArgs, bool* auto_setup_scope );
+	static Dart_NativeFunction resolveNameHandler( Dart_Handle nameHandle, int numArgs, bool *autoSetupScope );
 
 	// Dart_NativeFunction - this is used for all callbacks, so we can use std::function's instead of c function pointers
 	static void nativeCallbackHandler( Dart_NativeArguments args );

--- a/src/cidart/Script.h
+++ b/src/cidart/Script.h
@@ -56,7 +56,7 @@ class Script {
 	static void nativeCallbackHandler( Dart_NativeArguments args );
 
 	static void printNative( Dart_NativeArguments arguments );
-	static void toCinder( Dart_NativeArguments arguments );
+	void toCinder( Dart_NativeArguments arguments );
 
 	std::string  loadSourceImpl( const ci::fs::path &sourcePath );
 	std::string  loadSourceImpl( const ci::DataSourceRef &dataSource );

--- a/src/cidart/Types.cpp
+++ b/src/cidart/Types.cpp
@@ -252,6 +252,11 @@ Dart_Handle callFunction( Dart_Handle target, const string &name, int numArgs, D
 	return result;
 }
 
+Dart_Handle getField( Dart_Handle container, const char *name )
+{
+	return Dart_GetField( container, toDart( name ) );
+}
+
 Dart_Handle getField( Dart_Handle container, const string &name )
 {
 	return Dart_GetField( container, toDart( name ) );

--- a/src/cidart/Types.h
+++ b/src/cidart/Types.h
@@ -54,6 +54,7 @@ void getValue( Dart_Handle handle, ci::dvec3 *value );
 void getValue( Dart_Handle handle, ci::Rectf *value );
 void getValue( Dart_Handle handle, std::string *value );
 
+//! Returns the value of type \a T held by \a handle. If an error occurs, the value returned is default constructed and an error message is logged.
 template <typename T>
 T	getValue( Dart_Handle handle )
 {
@@ -62,9 +63,12 @@ T	getValue( Dart_Handle handle )
 	return result;
 }
 
-//! Returns a \a Dart_Handle that represents the field \a name on \a container. If an error occurs, an error handle is returned.
+//! Returns a \a Dart_Handle that represents the field \a name on \a container.
 Dart_Handle getField( Dart_Handle container, const std::string &name );
-//! Returns the value of type \a T for field \a name on the \a container. If an error occurs, the value returned is default constructed and an error message is printed to console.
+//! Returns a \a Dart_Handle that represents the field \a name on \a container.
+Dart_Handle getField( Dart_Handle container, const char *name );
+
+//! Returns the value of type \a T for field \a name on the \a container. If an error occurs, the value returned is default constructed and an error message is logged.
 template <typename T>
 T	getField( Dart_Handle container, const std::string &name )
 {
@@ -73,6 +77,7 @@ T	getField( Dart_Handle container, const std::string &name )
 	return result;
 }
 
+//! Returns the value of type \a T for field \a name on the \a container, or \a defaultValue if the field was null or an error occurs.
 template <typename T>
 T getFieldOrDefault( Dart_Handle container, const std::string &name, const T &defaultValue )
 {

--- a/src/cidart/Types.h
+++ b/src/cidart/Types.h
@@ -83,6 +83,17 @@ T getFieldOrDefault( Dart_Handle container, const std::string &name, const T &de
 		return cidart::getValue<T>( fieldHandle );
 }
 
+//! Returns the native argument of type \a T at \a index. If an error occurs, the value returned is default constructed and an error message is logged.
+template <typename T>
+T	getArg( Dart_NativeArguments args, int index )
+{
+	T result;
+	Dart_Handle argHandle = Dart_GetNativeArgument( args, index );
+
+	getValue( argHandle, &result );
+	return result;
+}
+
 bool hasFunction( Dart_Handle handle, const std::string &name );
 Dart_Handle callFunction( Dart_Handle target, const std::string &name, int numArgs = 0, Dart_Handle *args = nullptr );
 

--- a/test/NativeCallback/src/NativeCallbackApp.cpp
+++ b/test/NativeCallback/src/NativeCallbackApp.cpp
@@ -21,13 +21,6 @@ using namespace ci;
 using namespace ci::app;
 using namespace std;
 
-std::string sScriptMessage;
-
-void customNativeCallback( Dart_NativeArguments args )
-{
-	Dart_Handle firstArg = Dart_GetNativeArgument( args, 0 );
-	sScriptMessage = cidart::getValue<string>( firstArg );
-}
 
 class NativeCallbackApp : public AppNative {
   public:
@@ -38,6 +31,7 @@ class NativeCallbackApp : public AppNative {
 	void loadScript();
 
 	cidart::ScriptRef	mScript;
+	std::string			mScriptMessage;
 	gl::TextureFontRef	mTextureFont;
 };
 
@@ -54,8 +48,14 @@ void NativeCallbackApp::setup()
 
 void NativeCallbackApp::loadScript()
 {
+	auto opts = cidart::Script::Options().native( "customCallback",
+				[this] ( Dart_NativeArguments args ) {
+					Dart_Handle firstArg = Dart_GetNativeArgument( args, 0 );
+					mScriptMessage = cidart::getValue<string>( firstArg );
+				}
+	);
+
 	try {
-		auto opts = cidart::Script::Options().native( "customCallback", customNativeCallback );
 		mScript = cidart::Script::create( loadAsset( "main.dart" ), opts );
 	}
 	catch( Exception &exc ) {
@@ -73,9 +73,9 @@ void NativeCallbackApp::draw()
 {
 	gl::clear();
 
-	if( ! sScriptMessage.empty() ) {
+	if( ! mScriptMessage.empty() ) {
 		gl::color( Color( 0, 1, 1 ) );
-		mTextureFont->drawString( sScriptMessage, vec2( 10, getWindowCenter().y ) );
+		mTextureFont->drawString( mScriptMessage, vec2( 10, getWindowCenter().y ) );
 	}
 }
 

--- a/test/NativeCallback/src/NativeCallbackApp.cpp
+++ b/test/NativeCallback/src/NativeCallbackApp.cpp
@@ -50,8 +50,7 @@ void NativeCallbackApp::loadScript()
 {
 	auto opts = cidart::Script::Options().native( "customCallback",
 				[this] ( Dart_NativeArguments args ) {
-					Dart_Handle firstArg = Dart_GetNativeArgument( args, 0 );
-					mScriptMessage = cidart::getValue<string>( firstArg );
+					mScriptMessage = cidart::getArg<string>( args, 0 );
 				}
 	);
 


### PR DESCRIPTION
This is a big improvement over the previous method, which only supported c function pointers (Dart_NativeFunction) for callbacks. Now, your callback can be whatever a std::function is, so you can have context (your class) what your callback is called. This makes #6 unnecessary.  The overhead is one extra function call per callback, which I think is worth it. The system can be made to support the raw c function pointer callbacks, too, if needed for performance later on. 

Also:
- added cidart::getArg<T>()
- Script::create( fullPath ) overload