### PR TITLE
Use dart callNativeN() methods to support std::functions

### DIFF
--- a/src/cidart/Script.cpp
+++ b/src/cidart/Script.cpp
@@ -16,15 +16,15 @@ using namespace std;
 
 namespace cidart {
 
-Script::Options& Script::Options::native( const string &dartFuncName, Dart_NativeFunction nativeFn )
+Script::Options& Script::Options::native( const string &key, Dart_NativeFunction nativeFn )
 {
-	mNativeCallbackMap[dartFuncName] = nativeFn;
+	mNativeCallbackMap[key] = nativeFn;
 	return *this;
 }
 
-Script::Options& Script::Options::native( const string &dartFuncName, const FunctionCallback &nativeFn )
+Script::Options& Script::Options::native( const string &key, const FunctionCallback &nativeFn )
 {
-	mFunctionCallbackMap[dartFuncName] = nativeFn;
+	mFunctionCallbackMap[key] = nativeFn;
 	return *this;
 }
 

--- a/src/cidart/Script.cpp
+++ b/src/cidart/Script.cpp
@@ -254,7 +254,7 @@ void Script::callNativeFunctionHandler( Dart_NativeArguments args )
 {
 	Script *script = static_cast<Script *>( Dart_CurrentIsolateData() );
 
-	const string &callbackKey = getArg<string>( args, 0 ); // first arg is always the callbackId
+	string callbackKey = getArg<string>( args, 0 ); // first arg is always the callbackId
 	auto &callbackMap = script->mFunctionCallbackMap;
 
 	auto functionIt = callbackMap.find( callbackKey );

--- a/src/cidart/Script.cpp
+++ b/src/cidart/Script.cpp
@@ -16,16 +16,28 @@ using namespace std;
 
 namespace cidart {
 
+Script::Options& Script::Options::native( const string &dartFuncName, Dart_NativeFunction nativeFn )
+{
+	mNativeCallbackMap[dartFuncName] = nativeFn;
+	return *this;
+}
+
+Script::Options& Script::Options::native( const string &dartFuncName, const FunctionCallback &nativeFn )
+{
+	mFunctionCallbackMap[dartFuncName] = nativeFn;
+	return *this;
+}
+
 Script::Script( const fs::path &sourcePath, const Options &options )
 	: mIsolate( nullptr ), mMainScriptPath( sourcePath ),
-		mNativeCallbackMap( options.getNativeCallbackMap() ), mReceiveMapCallback( options.getReceiveMapCallback() )
+		mNativeCallbackMap( options.getNativeCallbackMap() ), mFunctionCallbackMap( options.getFunctionCallbackMap() ), mReceiveMapCallback( options.getReceiveMapCallback() )
 {
 	init();
 }
 
 Script::Script( const DataSourceRef &source, const Options &options )
 	: mIsolate( nullptr ), mMainScriptPath( source->getFilePath() ),
-		mNativeCallbackMap( options.getNativeCallbackMap() ), mReceiveMapCallback( options.getReceiveMapCallback() )
+		mNativeCallbackMap( options.getNativeCallbackMap() ), mFunctionCallbackMap( options.getFunctionCallbackMap() ), mReceiveMapCallback( options.getReceiveMapCallback() )
 {
 	init();
 }
@@ -36,7 +48,13 @@ void Script::init()
 		throw DartException( "invalid script path: " + mMainScriptPath.string() );
 
 	mNativeCallbackMap["printNative"] = printNative;
-	mNativeCallbackMap["toCinder"] = bind( &Script::toCinder, this, placeholders::_1 );
+	mFunctionCallbackMap["toCinder"] = bind( &Script::toCinder, this, placeholders::_1 ); // TODO: store in mNativeCallbackMap
+	mNativeCallbackMap["cidart::callNative0"] = callNativeFunctionHandler;
+	mNativeCallbackMap["cidart::callNative1"] = callNativeFunctionHandler;
+	mNativeCallbackMap["cidart::callNative2"] = callNativeFunctionHandler;
+	mNativeCallbackMap["cidart::callNative3"] = callNativeFunctionHandler;
+	mNativeCallbackMap["cidart::callNative4"] = callNativeFunctionHandler;
+	mNativeCallbackMap["cidart::callNative5"] = callNativeFunctionHandler;
 
 	const char *sourcePath = mMainScriptPath.string().c_str();
 
@@ -214,15 +232,17 @@ Dart_Handle Script::libraryTagHandler( Dart_LibraryTag tag, Dart_Handle library,
 // static
 Dart_NativeFunction Script::resolveNameHandler( Dart_Handle nameHandle, int numArgs, bool *autoSetupScope )
 {
-	CI_ASSERT( Dart_IsString( nameHandle ) );
-
 	DartScope enterScope;
 
-	Script *script = static_cast<Script *>( Dart_CurrentIsolateData() );
+	string name = getValue<string>( nameHandle );
 
-	// store the name handle and return our callback handler
-	script->mLatestNativeCallbackName = getValue<string>( nameHandle );
-	return nativeCallbackHandler;
+	Script *script = static_cast<Script *>( Dart_CurrentIsolateData() );
+	auto& callbackMap = script->mNativeCallbackMap;
+	auto functionIt = callbackMap.find( name );
+	if( functionIt != callbackMap.end() )
+		return functionIt->second;
+
+	return nullptr;
 }
 
 // ----------------------------------------------------------------------------------------------------
@@ -230,18 +250,18 @@ Dart_NativeFunction Script::resolveNameHandler( Dart_Handle nameHandle, int numA
 // ----------------------------------------------------------------------------------------------------
 
 // Static
-void Script::nativeCallbackHandler( Dart_NativeArguments args )
+void Script::callNativeFunctionHandler( Dart_NativeArguments args )
 {
 	Script *script = static_cast<Script *>( Dart_CurrentIsolateData() );
 
-	const string &name = script->mLatestNativeCallbackName;
-	auto& functionMap = script->mNativeCallbackMap;
+	const string &callbackKey = getArg<string>( args, 0 ); // first arg is always the callbackId
+	auto &callbackMap = script->mFunctionCallbackMap;
 
-	auto functionIt = functionMap.find( name );
-	if( functionIt != functionMap.end() )
+	auto functionIt = callbackMap.find( callbackKey );
+	if( functionIt != callbackMap.end() )
 		functionIt->second( args );
 	else
-		throwException( "Unhandled native callback for function name: " + name );
+		throwException( "Unhandled native callback for function with key: " + callbackKey );
 }
 
 // static

--- a/src/cidart/Script.h
+++ b/src/cidart/Script.h
@@ -66,11 +66,10 @@ class Script {
 	// Dart_NativeEntryResolver
 	static Dart_NativeFunction resolveNameHandler( Dart_Handle nameHandle, int numArgs, bool *autoSetupScope );
 
-	// Dart_NativeFunction - this is used for all callbacks, so we can use std::function's instead of c function pointers
-	static void callNativeFunctionHandler( Dart_NativeArguments args );
-
-	static void printNative( Dart_NativeArguments arguments );
-	void toCinder( Dart_NativeArguments arguments );
+	// Dart_NativeFunction's -
+	static void callNativeFunctionHandler( Dart_NativeArguments args ); // used to call std::function's
+	static void printNativeHandler( Dart_NativeArguments arguments );	// handles print() statements
+	static void toCinderHandler( Dart_NativeArguments arguments );		// toCinder() calls
 
 	void			init();
 	std::string		loadSourceImpl( const ci::fs::path &sourcePath );

--- a/src/cidart/Script.h
+++ b/src/cidart/Script.h
@@ -31,8 +31,8 @@ typedef std::function<void( const InfoMap& )>			ReceiveMapCallback;
 class Script {
   public:
 	struct Options {
-		Options& native( const std::string &dartFuncName, Dart_NativeFunction nativeFn );
-		Options& native( const std::string &dartFuncName, const FunctionCallback &callbackFn );
+		Options& native( const std::string &key, Dart_NativeFunction nativeFn );
+		Options& native( const std::string &key, const FunctionCallback &callbackFn );
 		Options& mapReceiver( const ReceiveMapCallback &callback )	{ mReceiveMapCallback = callback; return *this; }
 
 		const NativeCallbackMap&	getNativeCallbackMap() const	{ return mNativeCallbackMap; }
@@ -44,7 +44,7 @@ class Script {
 	  private:
 		NativeCallbackMap			mNativeCallbackMap;
 		FunctionCallbackMap			mFunctionCallbackMap;
-		ReceiveMapCallback			mReceiveMapCallback; // TODO: remove ivar and store in FunctionCallbackMap
+		ReceiveMapCallback			mReceiveMapCallback;
 	};
 
 	//! Creates a new Script object from the dart file located at \a sourcePath.

--- a/src/cidart/cinder.dart
+++ b/src/cidart/cinder.dart
@@ -8,8 +8,8 @@ get _printClosure => ( s ) {
 	}
 };
 
-void printNative( String message ) native "printNative";
-void toCinder( Map<String, dynamic> data ) native "toCinder";
+void printNative( String message ) 			native "cidart::printNative";
+void toCinder( Map<String, dynamic> data ) 	native "cidart::toCinder";
 
 /// callNativeN methods allow the method to hook up to a std::function. On the C++ side, the first argument recieved will be 'id'.
 void callNative0( String id ) native "cidart::callNative0";

--- a/src/cidart/cinder.dart
+++ b/src/cidart/cinder.dart
@@ -11,13 +11,13 @@ get _printClosure => ( s ) {
 void printNative( String message ) 			native "cidart::printNative";
 void toCinder( Map<String, dynamic> data ) 	native "cidart::toCinder";
 
-/// callNativeN methods allow the method to hook up to a std::function. On the C++ side, the first argument recieved will be 'id'.
-void callNative0( String id ) native "cidart::callNative0";
-void callNative1( String id, var arg1 ) native "cidart::callNative1";
-void callNative2( String id, var arg1, var arg2 ) native "cidart::callNative2";
-void callNative3( String id, var arg1, var arg2, var arg3 ) native "cidart::callNative3";
-void callNative4( String id, var arg1, var arg2, var arg3, var arg4 ) native "cidart::callNative4";
-void callNative5( String id, var arg1, var arg2, var arg3, var arg4, var arg5 ) native "cidart::callNative5";
+/// callNativeN methods allow the method to hook up to a std::function. On the C++ side, the first argument recieved will be 'key'.
+void callNative0( String key ) native "cidart::callNative0";
+void callNative1( String key, arg1 ) native "cidart::callNative1";
+void callNative2( String key, arg1, arg2 ) native "cidart::callNative2";
+void callNative3( String key, arg1, arg2, arg3 ) native "cidart::callNative3";
+void callNative4( String key, arg1, arg2, arg3, arg4 ) native "cidart::callNative4";
+void callNative5( String key, arg1, arg2, arg3, arg4, arg5 ) native "cidart::callNative5";
 
 class Color {
 	num r, g, b, a;

--- a/src/cidart/cinder.dart
+++ b/src/cidart/cinder.dart
@@ -11,6 +11,13 @@ get _printClosure => ( s ) {
 void printNative( String message ) native "printNative";
 void toCinder( Map<String, dynamic> data ) native "toCinder";
 
+/// callNativeN methods allow the method to hook up to a std::function. On the C++ side, the first argument recieved will be 'id'.
+void callNative0( String id ) native "cidart::callNative0";
+void callNative1( String id, var arg1 ) native "cidart::callNative1";
+void callNative2( String id, var arg1, var arg2 ) native "cidart::callNative2";
+void callNative3( String id, var arg1, var arg2, var arg3 ) native "cidart::callNative3";
+void callNative4( String id, var arg1, var arg2, var arg3, var arg4 ) native "cidart::callNative4";
+void callNative5( String id, var arg1, var arg2, var arg3, var arg4, var arg5 ) native "cidart::callNative5";
 
 class Color {
 	num r, g, b, a;

--- a/test/CallbackTest/assets/benchmark_callbacks.dart
+++ b/test/CallbackTest/assets/benchmark_callbacks.dart
@@ -6,15 +6,17 @@ void incrStdFunction( int i ) => ci.callNative1( "incrStdFunction", i );
 // routes to a Dart_NativeFunction directly
 void incrNative( int i ) native "incrNative";
 
+const int numIterations = 1000000; // must match the numbers in the dart benchmarks;
+
 void runIncrStdFunction()
 {
-	for( int i = 0; i < 1000000; i++ )
+	for( int i = 0; i < numIterations; i++ )
 		incrStdFunction( 1 );
 }
 
 void runIncrNative()
 {
-	for( int i = 0; i < 1000000; i++ )
+	for( int i = 0; i < numIterations; i++ )
 		incrNative( 1 );
 }
 

--- a/test/CallbackTest/assets/benchmark_callbacks.dart
+++ b/test/CallbackTest/assets/benchmark_callbacks.dart
@@ -1,0 +1,23 @@
+import 'cinder.dart' as ci;
+
+// proxy to allow it to be hooked up to a std::function:
+void incrStdFunction( int i ) => ci.callNative1( "incrStdFunction", i );
+
+// routes to a Dart_NativeFunction directly
+void incrNative( int i ) native "incrNative";
+
+void runIncrStdFunction()
+{
+	for( int i = 0; i < 1000000; i++ )
+		incrStdFunction( 1 );
+}
+
+void runIncrNative()
+{
+	for( int i = 0; i < 1000000; i++ )
+		incrNative( 1 );
+}
+
+void main()
+{
+}

--- a/test/CallbackTest/assets/test_callback.dart
+++ b/test/CallbackTest/assets/test_callback.dart
@@ -1,5 +1,10 @@
+import 'cinder.dart' as ci;
 
-void myCallback( String message ) native "myCallback";
+// proxy to allow it to be hooked up to a std::function:
+void myCallback( String message ) => ci.callNative1( "myCallback", message );
+
+// routes to a Dart_NativeFunction directly
+// void myCallback( String message ) native "myCallback";
 
 void main()
 {

--- a/test/CallbackTest/assets/test_callback.dart
+++ b/test/CallbackTest/assets/test_callback.dart
@@ -9,8 +9,8 @@ void myCallback( String message ) => ci.callNative1( "myCallback", message );
 void main()
 {
 	print("1");
-	myCallback( "Hey Hey" );
+	myCallback( "Hey Joe" );
 	print("2");
-	myCallback( "Hey Hey" );
+	myCallback( "Hey Shmoe" );
 	print("3");
 }


### PR DESCRIPTION
This is in order to address the bug reported in #14 (thanks @Kaosumaru).

The solution isn't pretty, basically there's no current way to use std::function's directly with dart native callbacks, since they must be c function pointers and there is nowhere to store a pointer to userData. So instead, we must first route through some other mechanism that can allow us to retrieve the C++-side data, which is currently a `std::function`.

There is a considerable slowdown introduced here over using raw `Dart_NativeFunction`s, from my measurments it is about 5.5x slower in release / macbook pro (with 1 million callbacks, ~37ns per `Dart_NativeFunction`, ~206ns when routed through the new `callNativeN()` dart methods,  see the new benchmark in test/CallbackTest for details). It looks like roughly 25% of this is coming from the extra `Dart_NewStringFromCString` call, would will be mitigated in more real-world cases that have more complex arguments passed back other than an int, and also roughly 12% in the extra map lookup. These could probably both be optimized by using an identical hash function on each side and using an int as key, but I don't think it is necessary now, I'd rather wait and see if the Dart VM team will add per-callback userData, if they do we would remove this mechanism.

In any event, you can also now add regular `Dart_NativeFunction` callbacks for performance-sensitive areas, though you'd have to sort out context on your own.

One unfortunate breaking change is that the first element of `Dart_NativeArguments` will now be the name of the native key.