### PR TITLE
Added support for vec4 and mat4 loading.

### DIFF
--- a/samples/InfoMap/src/InfoMapApp.cpp
+++ b/samples/InfoMap/src/InfoMapApp.cpp
@@ -63,7 +63,7 @@ void InfoMapApp::loadScript()
 
 void InfoMapApp::receiveMap( const cidart::InfoMap &info )
 {
-	CI_LOG_I( "info map received, number of elemnts: " << info.size() );
+	CI_LOG_I( "Info map received, number of elements: " << info.size() );
 	for( auto &mp : info ) {
 		CI_LOG_I( "\tkey: " << mp.first << ", value type: " << cidart::getTypeName( mp.second ) );
 	}

--- a/src/cidart/Types.cpp
+++ b/src/cidart/Types.cpp
@@ -263,6 +263,40 @@ void getValue( Dart_Handle handle, ci::dvec4 *value )
 	value->w = getValue<double>( w );
 }
 
+void getValue( Dart_Handle handle, ci::mat4 *value )
+{
+    Dart_Handle r1x = getField( handle, "r1x" );
+    Dart_Handle r2x = getField( handle, "r2x" );
+    Dart_Handle r3x = getField( handle, "r3x" );
+    Dart_Handle r4x = getField( handle, "r4x" );
+    Dart_Handle r1y = getField( handle, "r1y" );
+    Dart_Handle r2y = getField( handle, "r2y" );
+    Dart_Handle r3y = getField( handle, "r3y" );
+    Dart_Handle r4y = getField( handle, "r4y" );
+    Dart_Handle r1z = getField( handle, "r1z" );
+    Dart_Handle r2z = getField( handle, "r2z" );
+    Dart_Handle r3z = getField( handle, "r3z" );
+    Dart_Handle r4z = getField( handle, "r4z" );
+    Dart_Handle r1w = getField( handle, "r1w" );
+    Dart_Handle r2w = getField( handle, "r2w" );
+    Dart_Handle r3w = getField( handle, "r3w" );
+    Dart_Handle r4w = getField( handle, "r4w" );
+    
+    if( Dart_IsError( r1x ) || Dart_IsError( r2x ) || Dart_IsError( r3x ) || Dart_IsError( r4x ) ||
+        Dart_IsError( r1y ) || Dart_IsError( r2y ) || Dart_IsError( r3y ) || Dart_IsError( r4y ) ||
+        Dart_IsError( r1z ) || Dart_IsError( r2z ) || Dart_IsError( r3z ) || Dart_IsError( r4z ) ||
+        Dart_IsError( r1w ) || Dart_IsError( r2w ) || Dart_IsError( r3w ) || Dart_IsError( r4w ) ) {
+        CI_LOG_E( "expected handle to have fields 'r1x', 'r2x', 'r3x', 'r4x', 'r1y', 'r2y', 'r3y', 'r4y', 'r1z', 'r2z', 'r3z', 'r4z', 'r1w', 'r2w', 'r3w', 'r4w'" );
+        return;
+    }
+    float vals[16] = { getValue<float>( r1x ), getValue<float>( r2x ), getValue<float>( r3x ), getValue<float>( r4x ),
+                       getValue<float>( r1y ), getValue<float>( r2y ), getValue<float>( r3y ), getValue<float>( r4y ),
+                       getValue<float>( r1z ), getValue<float>( r2z ), getValue<float>( r3z ), getValue<float>( r4z ),
+                       getValue<float>( r1w ), getValue<float>( r2w ), getValue<float>( r3w ), getValue<float>( r4w ) };
+    
+    *value = glm::make_mat4( vals );
+}
+    
 void getValue( Dart_Handle handle, ci::Rectf *value )
 {
 	Dart_Handle x1 = getField( handle, "x1" );

--- a/src/cidart/Types.h
+++ b/src/cidart/Types.h
@@ -41,6 +41,7 @@ void getValue( Dart_Handle handle, ci::dvec3 *value );
 void getValue( Dart_Handle handle, ci::ivec4 *value );
 void getValue( Dart_Handle handle, ci::vec4 *value );
 void getValue( Dart_Handle handle, ci::dvec4 *value );
+void getValue( Dart_Handle handle, ci::mat4 *value );
 void getValue( Dart_Handle handle, ci::Rectf *value );
 void getValue( Dart_Handle handle, ci::log::Level *value );
 void getValue( Dart_Handle handle, std::string *value );

--- a/src/cidart/cinder.dart
+++ b/src/cidart/cinder.dart
@@ -55,6 +55,12 @@ class ivec3 {
 	ivec3( this.x, this.y );
 }
 
+class vec4 {
+	num x, y, z, w;
+	
+	vec4( this.x, this.y, this.z, this.w );
+}
+
 class Color {
 	num r, g, b, a;
 
@@ -65,6 +71,15 @@ class Rect {
 	num x1, x2, y1, y2;
 
 	Rect( this.x1, this.y1, this.x2, this.y2 );
+}
+
+class mat4 {
+	num r1x, r2x, r3x, r4x, r1y, r2y, r3y, r4y, r1z, r2z, r3z, r4z, r1w, r2w, r3w, r4w;
+	
+	mat4( this.r1x, this.r2x, this.r3x, this.r4x, 
+		  this.r1y, this.r2y, this.r3y, this.r4y, 
+		  this.r1z, this.r2z, this.r3z, this.r4z, 
+		  this.r1w, this.r2w, this.r3w, this.r4w );
 }
 
 enum LogLevel {


### PR DESCRIPTION
Found it helpful to be able to define and update target matrices for geometry systems.

I have been using it with InfoMap as follows:
Matrix4 test = new Matrix4.identity();
var info = {
        'testMat4': new mat4( test.getRow( 0 ).x, test.getRow( 1 ).x, test.getRow( 2 ).x, test.getRow( 3 ).x, test.getRow( 0 ).y, test.getRow( 1 ).y, test.getRow( 2 ).y, test.getRow( 3 ).y, test.getRow( 0 ).z, test.getRow( 1 ).z, test.getRow( 2 ).z, test.getRow( 3 ).z, test.getRow( 0 ).w, test.getRow( 1 ).w, test.getRow( 2 ).w, test.getRow( 3 ).w )
};
toCinder( info );

Fixed typo in InfoMapApp.cpp.
